### PR TITLE
support amqp client in pax-jms-artemis

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -65,6 +65,7 @@
         <jasypt.version>1.9.2_1</jasypt.version>
         <junit.version>4.12</junit.version>
         <log4j2.version>2.8.2</log4j2.version>
+        <qpid.jms.client.version>0.29.0</qpid.jms.client.version>
     </properties>
 
     <dependencyManagement>

--- a/pax-jms-api/src/main/java/org/ops4j/pax/jms/service/ConnectionFactoryFactory.java
+++ b/pax-jms-api/src/main/java/org/ops4j/pax/jms/service/ConnectionFactoryFactory.java
@@ -18,7 +18,6 @@ import javax.jms.ConnectionFactory;
 import javax.jms.JMSRuntimeException;
 import javax.jms.XAConnectionFactory;
 import java.util.Map;
-import java.util.Properties;
 
 /**
  * A factory for JMS ConnectionFactory
@@ -28,6 +27,12 @@ public interface ConnectionFactoryFactory {
     String JMS_CONNECTIONFACTORY_NAME   = "name";
 
     String JMS_CONNECTIONFACTORY_TYPE   = "type";
+
+    /**
+     * Specify which protocol to use. For example when using Artemis, the AMQP protocol may be used
+     * by setting the 'amqp' value.
+     */
+    String JMS_CONNECTIONFACTORY_PROTOCOL   = "protocol";
 
     /**
      * The "user" property that ConnectionFactory clients should supply a value for

--- a/pax-jms-artemis/pom.xml
+++ b/pax-jms-artemis/pom.xml
@@ -38,6 +38,13 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>artemis-server-osgi</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.qpid</groupId>
+            <artifactId>qpid-jms-client</artifactId>
+            <version>${qpid.jms.client.version}</version>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 

--- a/pax-jms-features/src/main/feature/feature.xml
+++ b/pax-jms-features/src/main/feature/feature.xml
@@ -31,7 +31,7 @@
         <bundle>mvn:org.ops4j.pax.jms/pax-jms-api/${project.version}</bundle>
         <bundle>mvn:org.ops4j.pax.jms/pax-jms-pool/${project.version}</bundle>
         <conditional>
-            <condition>req:type=karaf.feature;filter:="(|(osgi.identity=artemis-jms-client)(osgi.identity=artemis-core))"</condition>
+            <condition>req:type=karaf.feature;filter:="(|(osgi.identity=artemis-jms-client)(osgi.identity=artemis-amqp-client)(osgi.identity=artemis-core))"</condition>
             <bundle>mvn:org.ops4j.pax.jms/pax-jms-artemis/${project.version}</bundle>
         </conditional>
         <conditional>


### PR DESCRIPTION
!!! Needs https://github.com/ops4j/org.ops4j.pax.transx/pull/3 before merging !!!

Adds support for amqp client in pax-jms-artemis, solves #5. Adds a `protocol` property to the ConnectionFactoryFactory to use the amqp protocol.