### PR TITLE
clean up JMS resources on shutdown

### DIFF
--- a/pax-jms-pool/src/main/java/org/ops4j/pax/jms/pool/impl/Activator.java
+++ b/pax-jms-pool/src/main/java/org/ops4j/pax/jms/pool/impl/Activator.java
@@ -40,6 +40,7 @@ public class Activator implements BundleActivator {
     @Override
     public void stop(BundleContext context) throws Exception {
         registration.unregister();
+        configManager.destroy();
     }
 
 }

--- a/pax-jms-pool/src/main/java/org/ops4j/pax/jms/pool/impl/ConnectionFactoryConfigManager.java
+++ b/pax-jms-pool/src/main/java/org/ops4j/pax/jms/pool/impl/ConnectionFactoryConfigManager.java
@@ -54,7 +54,7 @@ public class ConnectionFactoryConfigManager implements ManagedServiceFactory {
     }
 
     @Override
-    public void updated(final String pid, final Dictionary config) throws ConfigurationException {
+    public synchronized void updated(final String pid, final Dictionary config) throws ConfigurationException {
         deleted(pid);
         if (config == null) {
             return;
@@ -122,10 +122,16 @@ public class ConnectionFactoryConfigManager implements ManagedServiceFactory {
     }
 
     @Override
-    public void deleted(String pid) {
+    public synchronized void deleted(String pid) {
         ServiceTracker<?,?> tracker = trackers.remove(pid);
         if (tracker != null) {
             tracker.close();
+        }
+    }
+
+    synchronized void destroy() {
+        for (String pid : trackers.keySet()) {
+            deleted(pid);
         }
     }
 


### PR DESCRIPTION
This fixes #8. The fix is similar to what is done in [ActiveMQServiceFactory](https://github.com/apache/activemq/blob/master/activemq-osgi/src/main/java/org/apache/activemq/osgi/ActiveMQServiceFactory.java#L175)