### PR TITLE
Fixing ConcurrentModificationException

### DIFF
--- a/pax-jms-config/src/main/java/org/ops4j/pax/jms/config/impl/ConnectionFactoryConfigManager.java
+++ b/pax-jms-config/src/main/java/org/ops4j/pax/jms/config/impl/ConnectionFactoryConfigManager.java
@@ -29,9 +29,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Dictionary;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Watches for ConnectionFactory configs in OSGi configuration admin and creates / destroys the trackers
@@ -53,7 +53,7 @@ public class ConnectionFactoryConfigManager implements ManagedServiceFactory {
     public ConnectionFactoryConfigManager(BundleContext context, ExternalConfigLoader externalConfigLoader) {
         this.context = context;
         this.externalConfigLoader = externalConfigLoader;
-        this.trackers = new HashMap<>();
+        this.trackers = new ConcurrentHashMap<>();
     }
 
     @Override
@@ -62,7 +62,7 @@ public class ConnectionFactoryConfigManager implements ManagedServiceFactory {
     }
 
     @Override
-    public synchronized void updated(final String pid, final Dictionary config) throws ConfigurationException {
+    public void updated(final String pid, final Dictionary config) throws ConfigurationException {
         deleted(pid);
         if (config == null) {
             return;
@@ -169,14 +169,14 @@ public class ConnectionFactoryConfigManager implements ManagedServiceFactory {
     }
 
     @Override
-    public synchronized void deleted(String pid) {
+    public void deleted(String pid) {
         ServiceTracker<?, ?> tracker = trackers.remove(pid);
         if (tracker != null) {
             tracker.close();
         }
     }
 
-    synchronized void destroy() {
+    void destroy() {
         for (String pid : trackers.keySet()) {
             deleted(pid);
         }


### PR DESCRIPTION
Hi,

in my case I was getting ConcurrentModificationException from inside of org.ops4j.pax.jms.config.impl.ConnectionFactoryConfigManager#destroy. I've changed trackers from HashMap to ConcurrentHashMap and exception is fixed.

If you want, feel free to use this change.

Notice:
I've tried to register in project's Jira but was getting error - that user has no access ( on email verify page ). I've received confirmation email, but when I clicked on the link in email to verify, I got error - that account does not have access.