### PR TITLE
fixes #18 support ibmmq connectionNameList with host1:port,host2:port

### DIFF
--- a/pax-jms-ibmmq/src/main/test/java/org/ops4j/pax/jms/ibmmq/MQConnectionFactoryFactoryTest.java
+++ b/pax-jms-ibmmq/src/main/test/java/org/ops4j/pax/jms/ibmmq/MQConnectionFactoryFactoryTest.java
@@ -1,0 +1,45 @@
+package org.ops4j.pax.jms.ibmmq;
+
+import org.junit.Test;
+
+import java.util.Hashtable;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class MQConnectionFactoryFactoryTest {
+
+    @Test
+    public void testConnectionNameList() {
+        final Map<String, Object> props = new Hashtable<>();
+        props.put("connectionNameList", "localhost:1414,172.0.0.1,172.0.0.2");
+        MQConnectionFactoryFactory.configureConnectionNameList(props);
+        assertEquals("localhost(1414),172.0.0.1,172.0.0.2", props.get("connectionNameList"));
+    }
+
+    @Test
+    public void testNoConnectionNameList() {
+        final Map<String, Object> props = new Hashtable<>();
+        props.put("hostName", "localhost");
+        props.put("port", "1414");
+        MQConnectionFactoryFactory.configureConnectionNameList(props);
+        assertNull(props.get("connectionNameList"));
+    }
+
+    @Test
+    public void testSingleHostConnectionNameList() {
+        final Map<String, Object> props = new Hashtable<>();
+        props.put("connectionNameList", "localhost:1414");
+        MQConnectionFactoryFactory.configureConnectionNameList(props);
+        assertEquals("localhost(1414)", props.get("connectionNameList"));
+    }
+
+    @Test
+    public void testSingleHostOnlyConnectionNameList() {
+        final Map<String, Object> props = new Hashtable<>();
+        props.put("connectionNameList", "localhost");
+        MQConnectionFactoryFactory.configureConnectionNameList(props);
+        assertEquals("localhost", props.get("connectionNameList"));
+    }
+}


### PR DESCRIPTION
support `connectionNameList` of the form `host1:port1,host2:port2,..` and convert to `host1(port1),host2(port2)`