### PR TITLE
Updating Netty to 4.1.95.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,8 +149,8 @@
         <version.commons-beanutils>1.9.4</version.commons-beanutils>
         <version.commons-collections>3.2.2</version.commons-collections>
         <version.commons-io>2.11.0</version.commons-io>
-        <version.io.netty>4.1.74.Final</version.io.netty>
-        <version.io.netty.tcnative>2.0.48.Final</version.io.netty.tcnative>
+        <version.io.netty>4.1.95.Final</version.io.netty>
+        <version.io.netty.tcnative>2.0.61.Final</version.io.netty.tcnative>
 
         <version.javax.el>3.0.0</version.javax.el>
         <version.javax.enterprise.cdi>2.0.SP1</version.javax.enterprise.cdi>


### PR DESCRIPTION
A fix for various CVE issues like https://nvd.nist.gov/vuln/detail/CVE-2023-34462